### PR TITLE
ENH: on_full policy

### DIFF
--- a/chest/__init__.py
+++ b/chest/__init__.py
@@ -1,2 +1,2 @@
-from .core import Chest
+from .core import Chest, full_policy
 from ._version import __version__

--- a/chest/core.py
+++ b/chest/core.py
@@ -70,6 +70,9 @@ class Chest(MutableMapping):
         A function like pickle.load or json.load that loads contents from file
     key_to_filename : function (optional)
         A function to determine filenames from key values
+    lock : Lock (optional)
+        The lock object to use to control access to the disk. If no lock is
+        given, a new threading lock will be used.
     mode : str (t or b)
         Binary or text mode for file storage
 
@@ -92,6 +95,7 @@ class Chest(MutableMapping):
                  dump=partial(pickle.dump, protocol=1),
                  load=pickle.load,
                  key_to_filename=key_to_filename,
+                 lock=None,
                  on_miss=_do_nothing, on_overflow=_do_nothing,
                  open=open,
                  open_many=_open_many,
@@ -124,7 +128,7 @@ class Chest(MutableMapping):
             if not os.path.exists(self.path):
                 os.mkdir(self.path)
 
-        self.lock = Lock()
+        self.lock = lock if lock is not None else Lock()
 
         # LRU state
         self.counter = 0

--- a/chest/core.py
+++ b/chest/core.py
@@ -215,11 +215,8 @@ class Chest(MutableMapping):
             except TypeError:
                 os.remove(fn)
                 raise
-        try:
-            self.memory_usage -= nbytes(self.inmem[key])
-            del self.inmem[key]
-        except KeyError:
-            pass
+        self.memory_usage -= nbytes(self.inmem[key])
+        del self.inmem[key]
 
     def get_from_disk(self, key):
         """ Pull value from disk into memory """

--- a/chest/core.py
+++ b/chest/core.py
@@ -64,9 +64,11 @@ def _open_many(fnames, mode='rb'):
     fs = []
     for fn in fnames:
         fs.append(open(fn, mode=mode))
-    yield fs
-    for f in fs:
-        f.close()
+    try:
+        yield fs
+    finally:
+        for f in fs:
+            f.close()
 
 
 class Chest(MutableMapping):

--- a/chest/core.py
+++ b/chest/core.py
@@ -311,7 +311,6 @@ class Chest(MutableMapping):
 
         while self.memory_usage > self.available_memory:
             key, _ = self.heap.popitem()
-            data = self.inmem[key]
             try:
                 self.move_to_disk(key)
             except TypeError:
@@ -338,7 +337,6 @@ class Chest(MutableMapping):
 
     def __exit__(self, eType, eValue, eTrace):
         with self.lock:
-            L = os.listdir(self.path)
             if not self._explicitly_given_path and os.path.exists(self.path):
                 self.drop()  # pragma: no cover
 

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -1,4 +1,4 @@
-from chest.core import Chest, nbytes, key_to_filename
+from chest.core import Chest, nbytes, key_to_filename, full_policy
 import os
 import re
 import json
@@ -7,7 +7,6 @@ import pickle
 from contextlib import contextmanager
 import numpy as np
 from chest.utils import raises, raise_KeyError
-import time
 import hashlib
 
 
@@ -457,4 +456,22 @@ def test_prefetch():
         c.prefetch(1)
         assert not raises(KeyError, lambda: c[1])
         c.prefetch([1, 2])
+        assert not raises(KeyError, lambda: c[2])
+
+
+def test_available_disk_raise():
+    with tmp_chest(available_disk=0) as c:
+        c[1] = 1
+        assert not raises(KeyError, lambda: c[1])
+        assert raises(OSError, lambda: c.flush())
+
+
+def test_available_disk_pop_lru():
+    with tmp_chest(available_disk=100, on_full=full_policy.pop_lru) as c:
+        c[1] = 1
+        assert not raises(KeyError, lambda: c[1])
+        c[2] = 2
+        assert not raises(KeyError, lambda: c[2])
+        c.flush()
+        assert raises(KeyError, lambda: c[1])
         assert not raises(KeyError, lambda: c[2])

--- a/chest/tests/test_core.py
+++ b/chest/tests/test_core.py
@@ -1,4 +1,3 @@
-from chest.core import Chest, nbytes, key_to_filename, full_policy
 import os
 import re
 import json
@@ -8,6 +7,9 @@ from contextlib import contextmanager
 import numpy as np
 from chest.utils import raises, raise_KeyError
 import hashlib
+
+from chest.core import Chest, nbytes, key_to_filename, full_policy
+from chest.utils import PY3
 
 
 @contextmanager
@@ -467,7 +469,8 @@ def test_available_disk_raise():
 
 
 def test_available_disk_pop_lru():
-    with tmp_chest(available_disk=100, on_full=full_policy.pop_lru) as c:
+    with tmp_chest(available_disk=100 if PY3 else 94,
+                   on_full=full_policy.pop_lru) as c:
         c[1] = 1
         assert not raises(KeyError, lambda: c[1])
         c[2] = 2

--- a/chest/utils.py
+++ b/chest/utils.py
@@ -1,9 +1,12 @@
 import sys
 
-if sys.version_info[0] == 2:
-    from StringIO import StringIO as BytesIO
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY2:
+    from StringIO import StringIO as BytesIO  # pragma: no cover
 else:
-    from io import BytesIO
+    from io import BytesIO  # pragma: no cover
 
 
 def raises(err, lambda_):

--- a/chest/utils.py
+++ b/chest/utils.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info.major == 2:
+if sys.version_info[0] == 2:
     from StringIO import StringIO as BytesIO
 else:
     from io import BytesIO

--- a/chest/utils.py
+++ b/chest/utils.py
@@ -1,6 +1,14 @@
-def raises(err, lamda):
+import sys
+
+if sys.version_info.major == 2:
+    from StringIO import StringIO as BytesIO
+else:
+    from io import BytesIO
+
+
+def raises(err, lambda_):
     try:
-        lamda()
+        lambda_()
         return False
     except err:
         return True


### PR DESCRIPTION
Allows a user to set a maximum disk usage and a policy defining what to do when the max disk is used and a new entry must be added.

The two options are currently:
1. `raise_`: raise an `OSError` indicating you ran out of space.
2. `pop_lru`: rotate the least recently used element out of the chest.

Users may pass any callable here; however, these two are defined for them.
