### PR TITLE
Import MutableMapping from collections.abc

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -1,4 +1,7 @@
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # pragma: no cover
+    from collections import MutableMapping  # pragma: no cover
 from functools import partial
 from threading import Lock
 from contextlib import contextmanager


### PR DESCRIPTION
Python 3.3 and above moved the abstract base classes to their own
module under collections, collections.abc. Import from that location,
falling back if required for Python 3.2.

Fixes #29